### PR TITLE
make install supports DESTDIR now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,14 +192,14 @@ clean-tools:
 install: install-dgsh install-tools
 
 install-dgsh: $(EXECUTABLES) $(LIBEXECUTABLES) $(LIBS)
-	-mkdir -p $(PREFIX)/bin
-	-mkdir -p $(PREFIX)/lib
-	-mkdir -p $(PREFIX)/libexec/dgsh
-	-mkdir -p $(PREFIX)/share/man/man1
-	install $(EXECUTABLES) $(PREFIX)/bin
-	install $(LIBEXECUTABLES) $(PREFIX)/libexec/dgsh
-	install $(LIBS) $(PREFIX)/lib
-	install -m 644 $(MANSRC) $(PREFIX)/share/man/man1
+	-mkdir -p $(DESTDIR)$(PREFIX)/bin
+	-mkdir -p $(DESTDIR)$(PREFIX)/lib
+	-mkdir -p $(DESTDIR)$(PREFIX)/libexec/dgsh
+	-mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
+	install $(EXECUTABLES) $(DESTDIR)$(PREFIX)/bin
+	install $(LIBEXECUTABLES) $(DESTDIR)$(PREFIX)/libexec/dgsh
+	install $(LIBS) $(DESTDIR)$(PREFIX)/lib
+	install -m 644 $(MANSRC) $(DESTDIR)$(PREFIX)/share/man/man1
 
 install-tools:
 	$(MAKE) -C $(TOOLS) install

--- a/unix-dgsh-tools/Makefile
+++ b/unix-dgsh-tools/Makefile
@@ -82,12 +82,12 @@ install: cat tee
 	$(MAKE) -C diffutils install
 	$(MAKE) -C grep install
 	# Install last to overwrite standard tools of coreutils
-	install cat $(DGSHPATH)
-	install tee $(DGSHPATH)
-	install secho $(DGSHPATH)
-	install pecho $(DGSHPATH)
-	install fft-input $(DGSHPATH)
-	install w $(DGSHPATH)
+	install cat $(DESTDIR)$(DGSHPATH)
+	install tee $(DESTDIR)$(DGSHPATH)
+	install secho $(DESTDIR)$(DGSHPATH)
+	install pecho $(DESTDIR)$(DGSHPATH)
+	install fft-input $(DESTDIR)$(DGSHPATH)
+	install w $(DESTDIR)$(DGSHPATH)
 	./install-wrapped.sh
 
 cat: cat.sh

--- a/unix-dgsh-tools/install-wrapped.sh
+++ b/unix-dgsh-tools/install-wrapped.sh
@@ -3,7 +3,7 @@
 # Install the commands wrapped by dgsh-wrap
 #
 
-DGPATH=$PREFIX/libexec/dgsh
+DGPATH=$DESTDIR$PREFIX/libexec/dgsh
 mkdir -p $DGPATH
 
 # Remove comments and blank lines


### PR DESCRIPTION
Added support of GNU-style standard $DESTDIR variable (usually unset)
for easy packaging by package maintainers.