### PR TITLE
dgsh-httpval: fix build with Glibc 2.26

### DIFF
--- a/core-tools/src/dgsh-httpval.c
+++ b/core-tools/src/dgsh-httpval.c
@@ -48,6 +48,7 @@
 #include <time.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <inttypes.h>
 
 #include "kvstore.h"
 

--- a/core-tools/src/dgsh-httpval.c
+++ b/core-tools/src/dgsh-httpval.c
@@ -48,7 +48,7 @@
 #include <time.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <inttypes.h>
+#include <stdint.h>
 
 #include "kvstore.h"
 


### PR DESCRIPTION
Add `#include <inttypes.h>` fixes build with Glibc 2.26.