### PR TITLE
Update install-wrapped.sh

### DIFF
--- a/unix-tools/install-wrapped.sh
+++ b/unix-tools/install-wrapped.sh
@@ -49,6 +49,6 @@ while read mode name ; do
     esac
   done
   target=$DGPATH/$name
-  echo "#!$DGPATH/dgsh-wrap$opt" >$target
+  echo "#!$PREFIX/libexec/dgsh/dgsh-wrap$opt" >$target
   chmod 755 $target
 done


### PR DESCRIPTION
Line 52 echoes DESTDIR into wrapper scripts. When built in a sandbox, this breaks the dgsh programs after they have been moved out of the temporary build directory. Changed to fix.